### PR TITLE
Add support for Twitter cards for better social & sharing

### DIFF
--- a/data/2016-04.yaml
+++ b/data/2016-04.yaml
@@ -1,4 +1,7 @@
 title: "Talisker - a Web Application Runtime"
+description:
+    Talisker is an opinionated WSGI stack designed to standardise operational
+    concerns for running many Python services.
 date: 2016-04-14
 body: |
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,11 +1,18 @@
 <!doctype html>
 <html lang="en">
     <head>
+        <title>WYPy - West Yorkshire Python User Group</title>
+
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>WYPy - West Yorkshire Python User Group</title>
         <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
         <link href="//netdna.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet" />
+
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:site" content="@WYPython" />
+        <meta name="twitter:title" content="{{ meeting["title"] }}" />
+        <meta name="twitter:description" content="{{ meeting.get("description", "West Yorkshire Python User Group") }}" />
+
         <style>
         .header {
             background-color: #2b5b84;


### PR DESCRIPTION
We can add a description, or it will default to giving just "West Yorkshire Python User Group". Which could be changed.
